### PR TITLE
Add Link to DQM Squared Mirror

### DIFF
--- a/config.js
+++ b/config.js
@@ -156,6 +156,18 @@ const config = {
         ],
       },
     ],
+    DQM_Squared_Mirror: [
+      {
+        id: 'DQM_Squared_Mirror',
+        links: [
+          {
+            name: 'mDQM^2',
+            link: 'https://cmsweb.cern.ch/dqm/dqm-square',
+            run_link: (run_number) => `/tmp/content_parser_productionPARSER_run${run_number}`,
+          },
+        ],
+      },
+    ],
     Meetings: [
       {
         id: 'DQM_Meetings',


### PR DESCRIPTION
**Why**
- To make it easier to access mDQM^2 home page as well as the per-run page.

**UI Preview**
<img width="1248" alt="ui-preview" src="https://user-images.githubusercontent.com/86765241/127130616-3a846a30-1296-4ffe-8505-1c3dada81f02.png">

